### PR TITLE
Migrating to dnsruby, DNSSEC capable dns client library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased][unreleased]
 - nothing
 
+## [0.0.6] - 2015-09-28
+### Changed
+- Migrated from ruby library resolv to dnsruby to support more dns related checks
+
 ## [0.0.5] - 2015-08-05
 ### Removed
 - PTR lookups no longer end with a dot '.'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sensu-plugins-dns.gemspec
+dnsruby
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sensu-plugins-dns.gemspec
-gem 'dnsruby',	'1.5.8'
 gemspec
+gem 'dnsruby',  '1.5.8'
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sensu-plugins-dns.gemspec
-dnsruby
+gem 'dnsruby',	'1.5.8'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sensu-plugins-dns.gemspec
 gemspec
-

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sensu-plugins-dns.gemspec
 gemspec
-gem 'dnsruby',  '1.5.8'
 

--- a/bin/check-dns.rb
+++ b/bin/check-dns.rb
@@ -82,7 +82,7 @@ class DNS < Sensu::Plugin::Check::CLI
 
     begin
       entries = resolve_domain
-      rescue  Dnsruby::NXDomain => ed
+      rescue  Dnsruby::NXDomain
         output = "Could not resolve #{config[:domain]} #{config[:type]} record"
         critical(output)
         return

--- a/bin/check-dns.rb
+++ b/bin/check-dns.rb
@@ -80,13 +80,13 @@ class DNS < Sensu::Plugin::Check::CLI
   def run
     unknown 'No domain specified' if config[:domain].nil?
 
-   begin
-     entries = resolve_domain
-   rescue Exception => e
-     output =  "Couldn not resolve  #{config[:domain]}: #{e}"
-     config[:warn_only] ? warning(output) : critical(output)
-   return
-   end
+    begin
+      entries = resolve_domain
+      rescue Exception => e
+        output =  "Couldn not resolve  #{config[:domain]}: #{e}"
+        config[:warn_only] ? warning(output) : critical(output)
+      return
+    end
     puts entries.answer  if config[:debug]
     if entries.answer.length.zero?
       output = "Could not resolve #{config[:domain]} #{config[:type]} record"

--- a/bin/check-dns.rb
+++ b/bin/check-dns.rb
@@ -85,7 +85,7 @@ class DNS < Sensu::Plugin::Check::CLI
       rescue Exception => e
         output =  "Couldn not resolve  #{config[:domain]}: #{e}"
         config[:warn_only] ? warning(output) : critical(output)
-      return
+        return
     end
     puts entries.answer  if config[:debug]
     if entries.answer.length.zero?
@@ -97,9 +97,9 @@ class DNS < Sensu::Plugin::Check::CLI
       else
         b = entries.answer.first.to_s
       end
-    if  b.include?(config[:result])
-      ok "Resolved #{config[:domain]} #{config[:type]} included #{config[:result]}"
-    else
+      if  b.include?(config[:result])
+        ok "Resolved #{config[:domain]} #{config[:type]} included #{config[:result]}"
+      else
       critical "Resolved #{config[:domain]} #{config[:type]} did not include #{config[:result]}"
     end
     else

--- a/bin/check-dns.rb
+++ b/bin/check-dns.rb
@@ -92,7 +92,7 @@ class DNS < Sensu::Plugin::Check::CLI
       output = "Could not resolve #{config[:domain]}"
       config[:warn_only] ? warning(output) : critical(output)
     elsif config[:result]
-      if entries.answer.include?(config[:result])
+      if entries.answer.entries[0].address.to_s.include?(config[:result])
         ok "Resolved #{config[:domain]} including #{config[:result]}"
       else
         critical "Resolved #{config[:domain]} did not include #{config[:result]}"

--- a/bin/check-dns.rb
+++ b/bin/check-dns.rb
@@ -81,31 +81,29 @@ class DNS < Sensu::Plugin::Check::CLI
     unknown 'No domain specified' if config[:domain].nil?
 
    begin
-   entries = resolve_domain
-
+     entries = resolve_domain
    rescue Exception => e
-          output =  "Couldn not resolve  #{config[:domain]}: #{e}"
-          config[:warn_only] ? warning(output) : critical(output)
+     output =  "Couldn not resolve  #{config[:domain]}: #{e}"
+     config[:warn_only] ? warning(output) : critical(output)
    return
    end
     puts entries.answer  if config[:debug]
     if entries.answer.length.zero?
-	     output = "Could not resolve #{config[:domain]} #{config[:type]} record"
-	      config[:warn_only] ? warning(output) : critical(output)
+      output = "Could not resolve #{config[:domain]} #{config[:type]} record"
+      config[:warn_only] ? warning(output) : critical(output)
     elsif config[:result]
-	 if entries.answer.count > 1  
-         b = entries.answer.rrsets("#{config[:type]}").to_s
-         else
-		 b = entries.answer.first.to_s
-        end
-	if  b.include?(config[:result])
-        	ok "Resolved #{config[:domain]} #{config[:type]} included #{config[:result]}"
-      	else
-        	critical "Resolved #{config[:domain]} #{config[:type]} did not include #{config[:result]}"
-        end
-	
+      if entries.answer.count > 1
+        b = entries.answer.rrsets("#{config[:type]}").to_s
+      else
+        b = entries.answer.first.to_s
+      end
+    if  b.include?(config[:result])
+      ok "Resolved #{config[:domain]} #{config[:type]} included #{config[:result]}"
     else
-      ok "Resolved #{config[:domain]} #{config[:type]} "
+      critical "Resolved #{config[:domain]} #{config[:type]} did not include #{config[:result]}"
+    end
+    else
+      ok "Resolved #{config[:domain]} #{config[:type]}"
     end
   end
 end

--- a/bin/check-dns.rb
+++ b/bin/check-dns.rb
@@ -100,8 +100,8 @@ class DNS < Sensu::Plugin::Check::CLI
       if  b.include?(config[:result])
         ok "Resolved #{config[:domain]} #{config[:type]} included #{config[:result]}"
       else
-      critical "Resolved #{config[:domain]} #{config[:type]} did not include #{config[:result]}"
-    end
+        critical "Resolved #{config[:domain]} #{config[:type]} did not include #{config[:result]}"
+      end
     else
       ok "Resolved #{config[:domain]} #{config[:type]}"
     end

--- a/bin/check-dns.rb
+++ b/bin/check-dns.rb
@@ -73,6 +73,7 @@ class DNS < Sensu::Plugin::Check::CLI
       entries = resolv.getnames(config[:domain]).map(&:to_s)
     else
 #      entries = resolv.query(config[:domain]).map(&:to_s)
+	
       entries = resolv.query(config[:domain])
 
     end
@@ -85,23 +86,19 @@ class DNS < Sensu::Plugin::Check::CLI
     unknown 'No domain specified' if config[:domain].nil?
 
     entries = resolve_domain
-    res = Dnsruby::Resolver.new
-    ret = res.query("example.com") # Defaults to A record
-    a_recs = ret.answer.rrset("A")
-    puts "Vastus: #{a_recs}"
-    puts "test"
-    puts entries.answer.rrset("A")
-#    if entries.length.zero?
-#      output = "Could not resolve #{config[:domain]}"
-#      config[:warn_only] ? warning(output) : critical(output)
-#    elsif config[:result]
-#      if entries.include?(config[:result])
-#        ok "Resolved #{config[:domain]} including #{config[:result]}"
-#      else
-#        critical "Resolved #{config[:domain]} did not include #{config[:result]}"
-#      end
-#    else
-#      ok "Resolved #{config[:domain]} #{config[:type]} records"
-#    end
+    puts entries.answer.entries[0].address.to_s  if config[:debug]
+
+    if entries.answer.length.zero?
+      output = "Could not resolve #{config[:domain]}"
+      config[:warn_only] ? warning(output) : critical(output)
+    elsif config[:result]
+      if entries.answer.include?(config[:result])
+        ok "Resolved #{config[:domain]} including #{config[:result]}"
+      else
+        critical "Resolved #{config[:domain]} did not include #{config[:result]}"
+      end
+    else
+      ok "Resolved #{config[:domain]} #{config[:type]} records"
+    end
   end
 end

--- a/bin/check-dns.rb
+++ b/bin/check-dns.rb
@@ -31,7 +31,6 @@
 
 require 'sensu-plugin/check/cli'
 require 'dnsruby'
-#include 'dnsruby'
 #
 # DNS
 #
@@ -71,7 +70,7 @@ class DNS < Sensu::Plugin::Check::CLI
   def resolve_domain
     resolv = config[:server].nil? ? Dnsruby::Resolver.new : Dnsruby::Resolver.new(nameserver: [config[:server]])
 
-      entries = resolv.query(config[:domain], config[:type])
+    entries = resolv.query(config[:domain], config[:type])
 
     puts "Entries: #{entries}" if config[:debug]
 
@@ -82,15 +81,15 @@ class DNS < Sensu::Plugin::Check::CLI
     unknown 'No domain specified' if config[:domain].nil?
 
 	begin
-	    entries = resolve_domain
+             entries = resolve_domain
 
-	rescue Exception => e
-		  output =  "Couldn not resolve  #{config[:domain]}: #{e}"
-		  config[:warn_only] ? warning(output) : critical(output)
-	  return
-	  end
-      	  puts entries.answer  if config[:debug]
-	if entries.answer.length.zero?
+        rescue Exception => e
+                 output =  "Couldn not resolve  #{config[:domain]}: #{e}"
+		 config[:warn_only] ? warning(output) : critical(output)
+        return
+	end
+    puts entries.answer  if config[:debug]
+    if entries.answer.length.zero?
 	      output = "Could not resolve #{config[:domain]} #{config[:type]} record"
 	      config[:warn_only] ? warning(output) : critical(output)
     elsif config[:result]
@@ -103,7 +102,7 @@ class DNS < Sensu::Plugin::Check::CLI
         	ok "Resolved #{config[:domain]} #{config[:type]} included #{config[:result]}"
       	else
         	critical "Resolved #{config[:domain]} #{config[:type]} did not include #{config[:result]}"
-      end
+        end
 	
     else
       ok "Resolved #{config[:domain]} #{config[:type]} "

--- a/bin/check-dns.rb
+++ b/bin/check-dns.rb
@@ -80,23 +80,23 @@ class DNS < Sensu::Plugin::Check::CLI
   def run
     unknown 'No domain specified' if config[:domain].nil?
 
-	begin
-             entries = resolve_domain
+   begin
+   entries = resolve_domain
 
-        rescue Exception => e
-                 output =  "Couldn not resolve  #{config[:domain]}: #{e}"
-		 config[:warn_only] ? warning(output) : critical(output)
-        return
-	end
+   rescue Exception => e
+          output =  "Couldn not resolve  #{config[:domain]}: #{e}"
+          config[:warn_only] ? warning(output) : critical(output)
+   return
+   end
     puts entries.answer  if config[:debug]
     if entries.answer.length.zero?
-	      output = "Could not resolve #{config[:domain]} #{config[:type]} record"
+	     output = "Could not resolve #{config[:domain]} #{config[:type]} record"
 	      config[:warn_only] ? warning(output) : critical(output)
     elsif config[:result]
-	if entries.answer.count > 1  
-	b = entries.answer.rrsets("#{config[:type]}").to_s
-        else 
-	   b = entries.answer.first.to_s
+	 if entries.answer.count > 1  
+         b = entries.answer.rrsets("#{config[:type]}").to_s
+         else
+		 b = entries.answer.first.to_s
         end
 	if  b.include?(config[:result])
         	ok "Resolved #{config[:domain]} #{config[:type]} included #{config[:result]}"

--- a/lib/sensu-plugins-dns/version.rb
+++ b/lib/sensu-plugins-dns/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsDNS
   module Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 5
+    PATCH = 6
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-dns.gemspec
+++ b/sensu-plugins-dns.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsDNS::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '1.2.0'
-  s.add_runtime_dependency 'dnsruby',  '1.5.8'
+  s.add_runtime_dependency 'dnsruby',  '1.58.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
@@ -49,6 +49,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'rubocop',                   '0.32.1'
   s.add_development_dependency 'yard',                      '~> 0.8'
-  s.add_development_dependency 'dnsruby',                    '1.5.8'
+  s.add_development_dependency 'dnsruby',                    '1.58.0'
 
 end

--- a/sensu-plugins-dns.gemspec
+++ b/sensu-plugins-dns.gemspec
@@ -49,4 +49,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'rubocop',                   '0.32.1'
   s.add_development_dependency 'yard',                      '~> 0.8'
+  s.add_development_dependency 'dnsruby',                    '1.5.8'
+
 end

--- a/sensu-plugins-dns.gemspec
+++ b/sensu-plugins-dns.gemspec
@@ -2,7 +2,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
-
+require 'dnsruby'
 if RUBY_VERSION < '2.0.0'
   require 'sensu-plugins-dns'
 else

--- a/sensu-plugins-dns.gemspec
+++ b/sensu-plugins-dns.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsDNS::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '1.2.0'
+  s.add_runtime_dependency 'dnsruby'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'

--- a/sensu-plugins-dns.gemspec
+++ b/sensu-plugins-dns.gemspec
@@ -50,5 +50,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop',                   '0.32.1'
   s.add_development_dependency 'yard',                      '~> 0.8'
   s.add_development_dependency 'dnsruby',                    '1.58.0'
-
 end

--- a/sensu-plugins-dns.gemspec
+++ b/sensu-plugins-dns.gemspec
@@ -2,7 +2,6 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
-require 'dnsruby'
 if RUBY_VERSION < '2.0.0'
   require 'sensu-plugins-dns'
 else
@@ -39,7 +38,7 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsDNS::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '1.2.0'
-  s.add_runtime_dependency 'dnsruby'
+  s.add_runtime_dependency 'dnsruby',  '1.5.8'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'

--- a/sensu-plugins-dns.gemspec
+++ b/sensu-plugins-dns.gemspec
@@ -49,5 +49,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'rubocop',                   '0.32.1'
   s.add_development_dependency 'yard',                      '~> 0.8'
-  s.add_development_dependency 'dnsruby',                    '1.58.0'
 end


### PR DESCRIPTION
Since rubys 'resolv' can't handle dnssec, i started migrating to https://rubygems.org/gems/dnsruby/versions/1.58.0 .

Current pull request should provide feature parity with original version, but does include new/changed dependencies.

