### PR TITLE
Feature/add regex support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-* nothing
+### Added
+* Adding support for Regular Expression matching
 
 ## [0.0.6] - 2015-09-28
 ### Changed


### PR DESCRIPTION
This is an enhancement / additional capability and is not covered by any issues, though it is conceivable that this could solve Issue #4 in a roundabout way.

- Updated Changelog
- RuboCop passes thanks to some minor refactoring

## Usage
    $ ruby check-dns.rb -s 8.8.8.8 -d 'google.com' -R '70.186.24.2[0-9]'
    DNS OK: Resolved google.com A matched 70.186.24.2[0-9]
    $ ruby check-dns.rb -s 8.8.8.8 -d 'google.com' -R '70.186.24.3[0-9]'
    DNS CRITICAL: Resolved google.com A did not match 70.186.24.3[0-9]