### PR TITLE
Feature - simple metrics check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 * Adding support for Regular Expression matching
+* Added simple response time metric
 
 ## [0.0.6] - 2015-09-28
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 ## Files
  * bin/check-dns.rb
+ * bin/metrics-dns.rb
 
 ## Usage
 

--- a/bin/metrics-dns.rb
+++ b/bin/metrics-dns.rb
@@ -1,0 +1,73 @@
+#! /usr/bin/env ruby
+#
+#   metrics-dns
+#
+# DESCRIPTION:
+#   This plugin gathers some simple DNS
+#   statistics, such as the amount of time taken
+#   to resolve a name (response time).
+#
+# OUTPUT:
+#   metric data
+#
+# PLATFORMS:
+#   Linux, BSD
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: dnsruby
+#
+# USAGE:
+#
+# LICENSE:
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+require 'sensu-plugin/metric/cli'
+require 'dnsruby'
+require 'benchmark'
+
+class DNSGraphite < Sensu::Plugin::Metric::CLI::Graphite
+  option :domain,
+         description: 'Domain to resolve (or ip if type PTR)',
+         short: '-d DOMAIN',
+         long: '--domain DOMAIN'
+
+  option :type,
+         description: 'Record type to resolve (A, AAAA, TXT, etc) use PTR for reverse lookup',
+         short: '-t RECORD',
+         long: '--type RECORD',
+         default: 'A'
+
+  option :server,
+         description: 'Server to use for resolution',
+         short: '-s SERVER',
+         long: '--server SERVER'
+
+  option :scheme,
+         description: 'Metric naming scheme, text to prepend to metric',
+         short: '-S SCHEME',
+         long: '--scheme SCHEME',
+         default: "#{Socket.gethostname}.dns"
+
+  def run
+    unknown 'No domain specified' if config[:domain].nil?
+
+    begin
+      resolver = config[:server].nil? ? Dnsruby::Resolver.new : Dnsruby::Resolver.new(nameserver: [config[:server]])
+      result = Benchmark.realtime { resolver.query(config[:domain], config[:type]) }
+
+      key_name = config[:domain].to_s.tr('.', '_')
+
+      # Response Time stat
+      output "#{config[:scheme]}.#{config[:type]}.#{key_name}.response_time", result.to_f.round(8)
+    rescue Dnsruby::NXDomain
+      critical "Could not resolve #{config[:domain]} #{config[:type]} record"
+    rescue => e
+      unknown e
+    end
+
+    # and exit 'ok'
+    ok
+  end
+end


### PR DESCRIPTION
This is an enhancement / additional capability and is not covered by any issues.

Added a metric for reporting on the time required to resolve a DNS query. This uses the `benchmark` standard library. Returns the time taken for the query in seconds, with a precision of up to eight decimal places.

## Usage

    # Specify a DNS server
    $ ruby bin/metrics-dns.rb -d google.com -s 8.8.4.4
    myhost.domain.tld.dns.A.google_com.response_time 0.01274058 1459897703
    
    # change the schema used for this metric
    $ ruby bin/metrics-dns.rb -d google.com -S foo_bar
    foo_bar.A.google_com.response_time 0.00593608 1459897734

## Output

This metric uses a default key schema of:

    <host>.<record type>.<domain>.response_time

Note that the "domain" piece is manipulated such that any `.` is replaced with `_`, making it easier to work with in graphite.