### PR TITLE
Upgrade dnsruby gem and convert dependency to semver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 * Adding support for Regular Expression matching
 * Added simple response time metric
+- Unlocked the dnsruby dependency to allow upgrades
 
 ## [0.0.6] - 2015-09-28
 ### Changed

--- a/sensu-plugins-dns.gemspec
+++ b/sensu-plugins-dns.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsDNS::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'dnsruby',  '1.58.0'
+  s.add_runtime_dependency 'dnsruby',  '~> 1.59', '>= 1.59.2'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
Fixes "warning: constant Dnsruby::TimeoutError is deprecated" at the beginning of check output on ruby 2.3 by pulling in the new `dnsruby` gem and allowing future upgrades without modifying this gem.

Previously this dependency was locked to exactly `1.58.0`.