### PR TITLE
Expose DNS query timeout as check parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - Added option for DNS server port
 - Added option for use TCP instead of UDP
 - Added `--class` argument to both metric and check scripts
+- Added DNS lookup timeout option
 
 ## [1.0.0] - 2016-05-11
 ### Added

--- a/bin/check-dns.rb
+++ b/bin/check-dns.rb
@@ -96,6 +96,13 @@ class DNS < Sensu::Plugin::Check::CLI
          long: '--use-tcp',
          boolean: true
 
+  option :timeout,
+         description: 'Set timeout for query',
+         short: '-T TIMEOUT',
+         long: '--timeout TIMEOUT',
+         proc: proc(&:to_i),
+         default: 5
+
   def resolve_domain
     dnsruby_config = {}
     dnsruby_config[:nameserver] = [config[:server]] unless config[:server].nil?
@@ -104,6 +111,7 @@ class DNS < Sensu::Plugin::Check::CLI
     resolv = Dnsruby::Resolver.new(dnsruby_config)
     resolv.do_validation = true if config[:validate]
     entries = resolv.query(config[:domain], config[:type], config[:class])
+    resolv.query_timeout = config[:timeout]
     puts "Entries: #{entries}" if config[:debug]
 
     entries


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] Update README with any necessary configuration snippets
- [x] Binstubs are created if needed
- [x] RuboCop passes

bin/check-dns.rb:121:3: C: Assignment Branch Condition size for run is too high. [100.2/100]

Feel free to mangle the code so that the functionality fits the check
- [x] Existing tests pass 

Are there any?
#### Purpose

Add [timeout](https://github.com/alexdalitz/dnsruby/blob/6c4b0e7c226ac917dc480591453bcc328c96f820/lib/dnsruby/resolver.rb#L157) to the resolver lookup
