### PR TITLE
fixes #4 by downcasing the comparison and expanding ip shorthand using ipaddr lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - Added option for use TCP instead of UDP
 - Added `--class` argument to both metric and check scripts
 - Added DNS lookup timeout option
+- check-dns.rb will now ignore case and expand shorthand when comparing ipv4 and pev6 records by turning them into ipaddr objects for comparison (@majormoses)
 
 ## [1.0.0] - 2016-05-11
 ### Added


### PR DESCRIPTION
## Pull Request Checklist
#4 

Test output:
```
$ ./bin/check-dns.rb --domain google.com --type AAAA --result '2607:f8b0:4007:80d::200e'
DNS OK: Resolved UNCHECKED google.com AAAA included 2607:f8b0:4007:80d::200e

$ ./bin/check-dns.rb --domain google.com --type AAAA --result '2607:F8b0:4007:80d::200e'
DNS OK: Resolved UNCHECKED google.com AAAA included 2607:F8b0:4007:80d::200e
```

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
IPV6 addresses are hex based and different OS, tools, etc return them not always in the same case, this fixes issues relating to case sentitivity.
#### Known Compatablity Issues

