### PR TITLE
fixes #23 by using the right varibale name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+
+## [1.2.2] - 2017-07-15
+### Fixed
+- check-dns.rb: fixed a bug reported in #23 regarding an undefined variable only triggered when using the `--validate` flag. (@majormoses)
+
 ### Added
 - Testing for Ruby 2.4.1
 - Remove redundant testing code

--- a/bin/check-dns.rb
+++ b/bin/check-dns.rb
@@ -201,7 +201,7 @@ class DNS < Sensu::Plugin::Check::CLI
 
       elsif config[:validate]
         if entry.security_level != 'SECURE'
-          error << "Resolved  #{entry.security_level} #{config[:domain]} #{config[:type]}"
+          errors << "Resolved  #{entry.security_level} #{config[:domain]} #{config[:type]}"
         end
         success << "Resolved #{entry.security_level} #{config[:domain]} #{config[:type]}"
       else

--- a/lib/sensu-plugins-dns/version.rb
+++ b/lib/sensu-plugins-dns/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsDNS
   module Version
     MAJOR = 1
     MINOR = 2
-    PATCH = 1
+    PATCH = 2
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
## Pull Request Checklist

#23 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Testing Artifact
before:
```
$ bundle exec ./bin/check-dns.rb -d www.google.com --validate
Check failed to run: undefined local variable or method `error' for #<DNS:0x005642499fb690>
Did you mean?  errors, ["./bin/check-dns.rb:204:in `block in check_results'", "./bin/check-dns.rb:165:in `each'", "./bin/check-dns.rb:165:in `check_results'", "./bin/check-dns.rb:229:in `run'", "/home/babrams/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sensu-plugin-1.4.5/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'"]
```

after:
```
$ bundle exec ./bin/check-dns.rb -d www.google.com
DNS OK: Resolved www.google.com A
```

#### Purpose
Fixed variable name

#### Known Compatibility Issues
none
