### PR TITLE
Pin version for public_suffix dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Fixed
+- explicitly depend on `public_suffix` version `~> 2` to keep support for ruby `2.0` (@mandre)
+
 ## [2.1.0] - 2018-05-30
 ### Changed
 - check-dns-zone.rb: `--timeout` is now also applied on the whois lookup (@eberkut)

--- a/sensu-plugins-dns.gemspec
+++ b/sensu-plugins-dns.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
 
   s.add_development_dependency 'bundler', '~> 1.7'
   s.add_runtime_dependency     'dnsruby', '~> 1.59', '>= 1.59.2'
+  s.add_runtime_dependency     'public_suffix',             '~> 2'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 1.3'
   s.add_runtime_dependency     'whois',                     '~> 4.0'


### PR DESCRIPTION
The public_suffix gem dropped support for ruby < 2.1.
As a consequence this breaks 1.x release with ruby 2.0. The public_suffix gem should should be pinned to an earlier version in sensu-plugins-dns .

I'm not exactly sure how to submit this to the appropriate branch. Please consider making a new 1.x release to include the fix.

For more context, we're seeing this in OpenStack:
https://bugs.launchpad.net/kolla/+bug/1781434

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
